### PR TITLE
New make tasks to clean and stop

### DIFF
--- a/infrastructure/docker/Makefile
+++ b/infrastructure/docker/Makefile
@@ -55,3 +55,10 @@ install-test-complete:
 
 install-test-basic:
 	docker run --name $(NAME) -d alastria-node:$(VERSION) bash -c "./start.sh $(TYPE)"
+
+clean:
+	docker images -a | grep "alastria" | awk '{print $$3}' | xargs docker rmi -f
+
+stop:
+	docker ps -a | grep "alastria" | awk '{print $$1}' | xargs -I % sh -c 'docker stop %; docker rm %;'
+	

--- a/infrastructure/docker/README.md
+++ b/infrastructure/docker/README.md
@@ -17,6 +17,8 @@ You can execute multiple tasks provided by the [Makefile](Makefile).
 | `install-test-complete` 	| Execute the Alastria node indicated by it's type, name, and different ports 	|
 | `install-test-basic`    	| Execute the Alastria node indicated by it's type and name                    	|
 | `node-shell`            	| Obtain a shell into a running node                                           	|
+| `clean`                   | Remove **all** Alastria docker images                                         |
+| `stop`                    | Stop **all** Alastria running nodes                                           |
 
 For each task you can use different values to customize it:
 

--- a/infrastructure/testnet/bin/start_network.sh
+++ b/infrastructure/testnet/bin/start_network.sh
@@ -31,15 +31,15 @@ start_validators () {
     elif [ "$VAL_NUM" -eq "2" ]; then
         ./bin/start_node.sh main
         ./bin/start_node.sh validator1
-        sleep 3
+        sleep 15
         geth --exec 'istanbul.propose("0xB50001FfA410F4D03663D69540c1C8e1C017e7e6", true)' attach network/main/geth.ipc
     elif [ "$VAL_NUM" -eq "3" ]; then
         ./bin/start_node.sh main
         ./bin/start_node.sh validator1
-        sleep 3
+        sleep 15
         geth --exec 'istanbul.propose("0xB50001FfA410F4D03663D69540c1C8e1C017e7e6", true)' attach network/main/geth.ipc
         ./bin/start_node.sh validator2
-        sleep 3
+        sleep 15
         geth --exec 'istanbul.propose("0xD8CfEA3B26B879f9D208975dFE8460F27520876b", true)' attach network/main/geth.ipc
         geth --exec 'istanbul.propose("0xD8CfEA3B26B879f9D208975dFE8460F27520876b", true)' attach network/validator1/geth.ipc
     else


### PR DESCRIPTION
Created two new make tasks:

`make clean` 
Clean all Alastria docker images (Including the base image)

`make stop`
Stop all Alastria running containers

