### PR TITLE
Changes on bootstrap.sh to point to testnet2

### DIFF
--- a/infrastructure/testnet/bin/bootstrap.sh
+++ b/infrastructure/testnet/bin/bootstrap.sh
@@ -8,7 +8,7 @@ sudo apt-get install wget git sudo netcat npm nodejs golang
 
 git clone https://github.com/alastria/alastria-node.git
 cd alastria-node/
-git checkout develop
+git checkout testnet2
 
 cd ..
 sudo -H $PWD/alastria-node/scripts/bootstrap.sh


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ X] Bug Fix

## Description
At this point, bootstrap script is obsolete as it loads the develop branch from alastria-node. With this PR, it will point to the right branch of alastria-node.

